### PR TITLE
test: add unit tests for GetItemByIdUseCase

### DIFF
--- a/__test__/items/functional/get-item-by-id.use-case.test.ts
+++ b/__test__/items/functional/get-item-by-id.use-case.test.ts
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+import GetItemByIdUseCase from '../../../src/use-cases/get-item-by-id.use-case';
+import * as itemRepository from '../../../src/repositories/item.repository';
+import ProductData from '../../../src/models/productData.model';
+
+jest.mock('../../../src/repositories/item.repository');
+
+describe('GetItemByIdUseCase', () => {
+  const mockId = 'test-id';
+  const mockProductData: ProductData = {
+    author: { name: 'Cristian', lastname: 'Gutierrez' },
+    items: [],
+    categories: []
+  };
+
+  it('should return product data when id is found', async () => {
+    // @ts-ignore
+    (itemRepository.getItemById as jest.Mock).mockResolvedValue(mockProductData);
+    const result = await GetItemByIdUseCase(mockId);
+    console.log(result)
+    expect(itemRepository.getItemById).toHaveBeenCalledWith(mockId);
+  });
+
+  it('should throw an error when id is not found', async () => {
+    const mockError = new Error('Item not found');
+    // @ts-ignore
+    (itemRepository.getItemById as jest.Mock).mockResolvedValue(mockProductData);
+
+    const result = await GetItemByIdUseCase(mockId);
+
+    expect(result).toEqual(mockProductData);
+    // @ts-ignore
+    (itemRepository.getItemById as jest.Mock).mockRejectedValue(mockError);
+
+    await expect(GetItemByIdUseCase(mockId)).rejects.toThrow('Item not found');
+    expect(itemRepository.getItemById).toHaveBeenCalledWith(mockId);
+  });
+});

--- a/__test__/items/functional/get-items-by-query.use-case.test.ts
+++ b/__test__/items/functional/get-items-by-query.use-case.test.ts
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+import GetItemsUseCase from '../../../src/use-cases/get-items-by-query.use-case';
+import * as itemRepository from '../../../src/repositories/item.repository';
+import ProductData from '../../../src/models/productData.model';
+
+jest.mock('../../../src/repositories/item.repository');
+
+describe('GetItemsUseCase', () => {
+  const mockQuery = 'test query';
+  const mockProductData: ProductData = {
+    author: { name: 'Cristian', lastname: 'Gutierrez' },
+    items: [],
+    categories: []
+  };
+
+  it('should return product data when query is successful', async () => {
+    // @ts-ignore
+    (itemRepository.getItemsByQuery as jest.Mock).mockResolvedValue(mockProductData);
+
+    const result = await GetItemsUseCase(mockQuery);
+
+    expect(result).toEqual(mockProductData);
+    expect(itemRepository.getItemsByQuery).toHaveBeenCalledWith(mockQuery);
+  });
+
+  it('should throw an error when query fails', async () => {
+    const mockError = new Error('Query failed');
+    // @ts-ignore
+    (itemRepository.getItemsByQuery as jest.Mock).mockRejectedValue(mockError);
+
+    await expect(GetItemsUseCase(mockQuery)).rejects.toThrow('Query failed');
+    expect(itemRepository.getItemsByQuery).toHaveBeenCalledWith(mockQuery);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "deploy": "vercel deploy --prod",
     "build": "npx tsc",
-    "dev": "nodemon index.ts"
+    "dev": "nodemon index.ts",
+    "test": "jest"
   },
   "author": "Cristian Gutierrez",
   "license": "ISC",


### PR DESCRIPTION
- Add unit tests for GetItemByIdUseCase to cover successful data retrieval and error handling scenarios.
- Mock the itemRepository.getItemById function to simulate different outcomes.