### PR TITLE
chore: add instrumentation pattern to use cases

### DIFF
--- a/src/instrumentation/instrumentation-use-case.ts
+++ b/src/instrumentation/instrumentation-use-case.ts
@@ -1,0 +1,17 @@
+const InstrumentUseCase = async <T>(useCase: () => Promise<T>, useCaseName: string): Promise<T> => {
+  const start = Date.now();
+  console.log(`Starting use case: ${useCaseName}`);
+
+  try {
+    const result = await useCase();
+    const duration = Date.now() - start;
+    console.log(`Completed use case: ${useCaseName} in ${duration}ms`);
+    return result;
+  } catch (error) {
+    const duration = Date.now() - start;
+    console.log(`Failed use case: ${useCaseName} in ${duration}ms`);
+    throw error;
+  }
+};
+
+export default InstrumentUseCase;

--- a/src/use-cases/get-item-by-id.use-case.ts
+++ b/src/use-cases/get-item-by-id.use-case.ts
@@ -1,8 +1,9 @@
 import ProductData from "../models/productData.model";
 import * as itemRepository from '../repositories/item.repository';
+import InstrumentUseCase from "../instrumentation/instrumentation-use-case";
 
 const GetItemByIdUseCase = async (id: string): Promise<ProductData> => {
-  return await itemRepository.getItemById(id)
+  return await InstrumentUseCase(() => itemRepository.getItemById(id), 'GetItemByIdUseCase');
 }
 
 export default GetItemByIdUseCase

--- a/src/use-cases/get-items-by-query.use-case.ts
+++ b/src/use-cases/get-items-by-query.use-case.ts
@@ -1,8 +1,9 @@
 import ProductData from "../models/productData.model";
 import * as itemRepository from '../repositories/item.repository';
+import InstrumentUseCase from "../instrumentation/instrumentation-use-case";
 
 const GetItemsUseCase = async (query: string): Promise<ProductData> => {
-  return await itemRepository.getItemsByQuery(query)
+  return await InstrumentUseCase(() => itemRepository.getItemsByQuery(query), 'GetItemsByQuery');
 }
 
 export default GetItemsUseCase


### PR DESCRIPTION
- Create an instrumentation function to log the start and end of the use case execution.
- Wrap the existing use case logic with the instrumentation function.
- Apply the instrumentation pattern to `GetItemByIdUseCase` and `GetItemsUseCase`.